### PR TITLE
fix(artifact): make sure the binaries don't depend on things in /tmp/build/

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -99,6 +99,8 @@ function main() {
 
     curl -fsSLo atc-router.tar.gz https://github.com/hutchic/atc-router/releases/download/$ATC_ROUTER_VERSION/$package_architecture-unknown-$OSTYPE.tar.gz
     tar -C /tmp/build -xvf atc-router.tar.gz
+
+    sed -i 's/\/tmp\/build//' `grep -l -I -r '\/tmp\/build' /tmp/build/`
 }
 
 # Retries a command a configurable number of times with backoff.

--- a/test.sh
+++ b/test.sh
@@ -11,6 +11,7 @@ export $(grep -v '^#' $SCRIPT_DIR/.env | xargs)
 
 function test() {
     cp -R /tmp/build/* /
+    mv /tmp/build /tmp/buffer # Check we didn't link dependencies to `/tmp/build/...`
 
     /usr/local/kong/bin/openssl version     # From kong-openssl test.sh
     ls -la /usr/local/kong/lib/libyaml.so   # From kong-openssl test.sh
@@ -22,6 +23,8 @@ function test() {
     ls -l /usr/local/openresty/lualib/resty/websocket/*.lua
     grep _VERSION /usr/local/openresty/lualib/resty/websocket/*.lua
     luarocks --version
+
+    mv /tmp/buffer /tmp/build
 }
 
 test


### PR DESCRIPTION
A test as well as the fix to avoid binaries depending on resources in `/tmp/build`.

Example:
```
luarocks --version

Configuration:
   Lua:
      Version    : 5.1
      Interpreter: /tmp/build/usr/local/openresty/luajit/bin/luajit (ok)
      LUA_DIR    : /tmp/build/usr/local/openresty/luajit (ok)
      LUA_BINDIR : /tmp/build/usr/local/openresty/luajit/bin (ok)
      LUA_INCDIR : /tmp/build/usr/local/openresty/luajit/include/luajit-2.1 (ok)
      LUA_LIBDIR : /tmp/build/usr/local/openresty/luajit/lib (ok)
```