### PR TITLE
fix(tests): downstream systems might not have xargs installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,10 @@ ARG DOCKER_REGISTRY=ghcr.io
 ARG DOCKER_IMAGE_NAME
 
 # List out all image permutations to trick dependabot
-FROM --platform=linux/amd64 ghcr.io/kong/kong-openssl:1.1.5-x86_64-linux-musl as x86_64-linux-musl
-FROM --platform=linux/amd64 ghcr.io/kong/kong-openssl:1.1.5-x86_64-linux-gnu as x86_64-linux-gnu
-FROM --platform=linux/arm64 ghcr.io/kong/kong-openssl:1.1.5-aarch64-linux-musl as aarch64-linux-musl
-FROM --platform=linux/arm64 ghcr.io/kong/kong-openssl:1.1.5-aarch64-linux-gnu as aarch64-linux-gnu
+FROM --platform=linux/amd64 ghcr.io/kong/kong-openssl:1.1.9-x86_64-linux-musl as x86_64-linux-musl
+FROM --platform=linux/amd64 ghcr.io/kong/kong-openssl:1.1.9-x86_64-linux-gnu as x86_64-linux-gnu
+FROM --platform=linux/arm64 ghcr.io/kong/kong-openssl:1.1.9-aarch64-linux-musl as aarch64-linux-musl
+FROM --platform=linux/arm64 ghcr.io/kong/kong-openssl:1.1.9-aarch64-linux-gnu as aarch64-linux-gnu
 
 
 # Run the build script

--- a/test.sh
+++ b/test.sh
@@ -7,7 +7,7 @@ if [ -n "${DEBUG:-}" ]; then
 fi
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-export $(grep -v '^#' $SCRIPT_DIR/.env | xargs)
+export $(grep -v '^#' $SCRIPT_DIR/.env)
 
 function test() {
     echo '--- testing kong runtime (openresty, luarocks) ---'


### PR DESCRIPTION
### Summary

Downstream docker images that re-run these tests for a sanity check might not have `xargs` available